### PR TITLE
fix(release): drop testpypi publish+verify from reusable — publishing must stay in caller

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -3,10 +3,6 @@ name: 'Reusable Python Release'
 on:
   workflow_call:
     inputs:
-      package-name:
-        description: 'PyPI distribution name (e.g. pyvider-cty, wrknv)'
-        type: string
-        required: true
       python-version:
         description: 'Python version to use'
         type: string
@@ -35,22 +31,18 @@ on:
         description: 'Create a GitHub release from the built artifacts. Set false when the caller was triggered by an existing release.'
         type: boolean
         default: true
-      publish-testpypi:
-        description: 'Publish built artifacts to TestPyPI'
-        type: boolean
-        default: false
-      verify-testpypi:
-        description: 'After TestPyPI publish, install from TestPyPI and assert the version via verify-import'
-        type: boolean
-        default: false
-      verify-import:
-        description: 'Python snippet that binds v to the installed package version, e.g. "import wrknv; v = wrknv.__version__"'
-        type: string
-        default: ''
 
 env:
   FORCE_COLOR: "1"
   UV_SYSTEM_PYTHON: "1"
+
+# Publishing (TestPyPI + PyPI) intentionally stays in caller workflows:
+# PyPI Trusted Publishing matches on OIDC job_workflow_ref, which points at
+# the workflow that actually runs the publish action. If publish ran here in
+# the reusable, every PyPI project would need its trusted publisher pointed
+# at provide-io/ci-tooling/python-release.yml, defeating per-repo isolation.
+# Callers consume the `release-artifacts` artifact from this workflow's build
+# job and run their own publish-testpypi / publish-pypi / sign-and-upload.
 
 jobs:
   # ==================================================================================
@@ -114,7 +106,7 @@ jobs:
         with:
           build-backend: ${{ inputs.build-backend }}
 
-      # Share artifacts with all downstream jobs (and with the caller's publish-pypi)
+      # Share artifacts with downstream caller jobs (publish-testpypi, publish-pypi, etc.)
       - name: 📤 Upload Build Artifacts
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
@@ -123,7 +115,7 @@ jobs:
           retention-days: 30
 
   # ==================================================================================
-  # 🏷️ Create GitHub Release
+  # 🏷️ Create GitHub Release (optional)
   # ==================================================================================
   github-release:
     name: 🏷️ GitHub Release
@@ -156,92 +148,20 @@ jobs:
           prerelease: ${{ inputs.prerelease }}
 
   # ==================================================================================
-  # 🧪 Publish to TestPyPI (optional)
-  # ==================================================================================
-  publish-testpypi:
-    name: 🧪 Publish to TestPyPI
-    needs: [build]
-    if: always() && needs.build.result == 'success' && inputs.publish-testpypi
-    runs-on: ubuntu-24.04
-    permissions:
-      id-token: write
-      contents: read
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/p/${{ inputs.package-name }}
-    steps:
-      # Download built artifacts for the publish action
-      - name: 📦 Download Build Artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
-        with:
-          name: release-artifacts
-          path: dist/
-
-      # Publish to TestPyPI via trusted publishing (OIDC)
-      - name: 📤 Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          skip-existing: true
-
-  # ==================================================================================
-  # ✅ Verify TestPyPI install (optional, depends on publish-testpypi)
-  # ==================================================================================
-  verify-testpypi:
-    name: ✅ Verify TestPyPI install
-    needs: [publish-testpypi]
-    if: always() && needs.publish-testpypi.result == 'success' && inputs.verify-testpypi
-    runs-on: ubuntu-24.04
-    steps:
-      # Checkout ci-tooling for the verify script. We use the caller's repo by default
-      # (checked-out implicitly) — pull the helper script via a shallow ci-tooling clone.
-      - name: 📥 Checkout ci-tooling helpers
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          repository: provide-io/ci-tooling
-          path: .ci-tooling
-          ref: main
-
-      # Python runtime for pip install + version assertion
-      - name: 🐍 Setup Python
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
-        with:
-          python-version: ${{ inputs.python-version }}
-          enable-cache: false
-
-      # Determine the version to verify against (from tag or from the release event)
-      - name: 🔖 Resolve version
-        id: ver
-        env:
-          REF_NAME: ${{ github.ref_name }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: .ci-tooling/scripts/release/resolve-tag-version.sh >> "$GITHUB_OUTPUT"
-
-      # Retry-loop install from TestPyPI and run the import-snippet version assertion
-      - name: ✅ Install from TestPyPI and verify
-        run: |
-          .ci-tooling/scripts/release/verify-testpypi.sh \
-            "${{ inputs.package-name }}" \
-            "${{ steps.ver.outputs.version }}" \
-            "${{ inputs.verify-import }}"
-
-  # ==================================================================================
   # 🚧 Publishing Gate
   # ==================================================================================
   publishing-gate:
     name: 🚧 Publishing Gate
-    needs: [build, github-release, publish-testpypi, verify-testpypi]
-    # Run whenever the build succeeded; downstream optional jobs may be skipped.
+    needs: [build, github-release]
+    # Run whenever the build succeeded; github-release may be skipped
     if: always() && needs.build.result == 'success'
     runs-on: ubuntu-24.04
     steps:
-      # Summary for humans; callers use `needs: [release]` on this workflow to gate publish-pypi
+      # Summary for humans; callers use `needs: [release]` on this workflow to gate publish-testpypi / publish-pypi
       - name: 📋 Report Gate Status
         env:
           R_BUILD: ${{ needs.build.result }}
           R_GHREL: ${{ needs.github-release.result }}
-          R_TEST:  ${{ needs.publish-testpypi.result }}
-          R_VERIFY: ${{ needs.verify-testpypi.result }}
         run: |
-          printf '## 🚧 Publishing Gate\n\nbuild=%s  github-release=%s  testpypi=%s  verify=%s\n\nArtifacts ready for caller publish.\n' \
-            "$R_BUILD" "$R_GHREL" "$R_TEST" "$R_VERIFY" >> "$GITHUB_STEP_SUMMARY"
+          printf '## 🚧 Publishing Gate\n\nbuild=%s  github-release=%s\n\nArtifacts (release-artifacts) ready for caller publish.\n' \
+            "$R_BUILD" "$R_GHREL" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Remove \`publish-testpypi\` and \`verify-testpypi\` jobs from the reusable \`python-release.yml\`.
- Drop associated inputs: \`package-name\`, \`publish-testpypi\`, \`verify-testpypi\`, \`verify-import\`.
- Keep helper scripts in \`scripts/release/\` so callers can consume them via \`actions/checkout\` of ci-tooling at a pinned ref.

## Why
PyPI Trusted Publishing matches the OIDC \`job_workflow_ref\` claim against the workflow that runs the publish action. When publish runs inside a reusable, \`job_workflow_ref\` points at the reusable — but each repo's TestPyPI/PyPI trusted publisher is configured for that repo's own \`release.yml\` + environment. Result: \`digest-mismatch: error\` on every attempt. Confirmed in wrknv v0.4.0rc1 pilot run 24851159799.

Moving publish back to caller workflows (where \`publish-pypi\` already lives) keeps all OIDC claims aligned with the configured trusted publishers and requires zero changes on the PyPI side across 12+ projects.

## Reusable coverage after this change
\`pre-release-tests → build → github-release (optional) → publishing-gate\`

Callers consume the \`release-artifacts\` artifact from the build job and run their own:
- \`publish-testpypi\` (OIDC env \`testpypi\`)
- \`verify-testpypi\` (uses \`scripts/release/{resolve-tag-version,verify-testpypi}.sh\` via checkout of ci-tooling)
- \`publish-pypi\` (OIDC env \`pypi\`)
- \`sign-and-upload\` (sigstore + SBOM + attach to release)

## Depends
- Will re-tag \`v0.4.1\` after merge so consumers (wrknv caller) pick up the fix without a version bump, since \`v0.4.1\` has only been consumed by the pilot in wrknv and never landed a successful run.

## Test plan
- [ ] Merge and re-tag \`v0.4.1\`.
- [ ] Re-run wrknv pilot v0.4.0rc1 pre-release end to end.
- [ ] Verify OIDC \`job_workflow_ref\` in publish-testpypi log matches \`provide-io/wrknv/.github/workflows/release.yml@refs/tags/v0.4.0rc1\`.